### PR TITLE
chore: bootstrap restart workflow from master

### DIFF
--- a/.cursor/rules/habitv-master.mdc
+++ b/.cursor/rules/habitv-master.mdc
@@ -1,0 +1,58 @@
+---
+description: Habitv restart-from-master governance rules for AI agents
+alwaysApply: true
+---
+
+# Habitv master modernization rules
+
+These rules apply to all AI-assisted work on the Habitv repository.
+They exist to keep modernization safe, incremental, and reviewable.
+
+## Java baseline
+
+- Always keep Java 8 compatibility unless an explicit tracker item
+  (e.g. HBTV-002 successor) says otherwise and is referenced in the PR.
+- Do not introduce Java 9+ language features or JDK 11/17/21-only APIs.
+- Any Java baseline migration must happen in a dedicated migration PR
+  with an ADR in `docs/decision-log.md`.
+
+## Architecture and scope
+
+- Do not rewrite architecture without a tracker item AND an ADR.
+- Do not perform opportunistic refactors or formatting changes.
+- Do not remove legacy code unless there is a dedicated deprecation PR
+  with a tracker item and migration notes.
+- Never mix unrelated fixes in the same branch.
+
+## Build and tests
+
+- Prefer deterministic Maven commands. Default validation:
+  `mvn -B -ntp -DskipTests validate`.
+- Do not run live provider/network tests in the default lifecycle.
+  Network or provider live tests must be opt-in via an explicit
+  profile or tracker item.
+- Do not change Maven module topology, plugin versions, or dependency
+  versions outside a scoped tracker item.
+
+## Branching and PRs
+
+- Use small PRs scoped to a single tracker item.
+- Use English for branches, commits, comments, docs, and PR text.
+- Keep linear history (no merge commits in feature branches).
+- Branch naming: `chore/...`, `build/...`, `ci/...`, `docs/...`,
+  `test/...`, `runtime/...`, `provider/...`, `fix/...`, `feature/...`.
+
+## Documentation discipline
+
+- Update `docs/dev-tracker.md` AND `docs/dev-tracker.json` for every
+  meaningful change so machine and human views stay aligned.
+- Update `docs/risk-register.md` when a risk is added, mitigated, or
+  realized.
+- Record cross-cutting decisions in `docs/decision-log.md` (ADR format).
+
+## Forbidden in this restart phase
+
+- No provider rewrites, no JavaFX migration, no JAXB regeneration,
+  no Maven deploy or distribution changes, and no runtime updater
+  changes unless an explicit dedicated tracker item covers them.
+- Never commit secrets, tokens, local absolute paths, or build outputs.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a defect in Habitv runtime, build, or plugins
+title: "bug: <short summary>"
+labels: ["bug", "triage"]
+assignees: []
+---
+
+## Environment
+
+- Java version (output of `java -version`):
+- Maven version (output of `mvn -v`):
+- OS and version:
+- Habitv version / commit SHA:
+- Affected module(s):
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should happen. -->
+
+## Actual behavior
+
+<!-- What actually happens. Include exact error messages. -->
+
+## Logs
+
+<!-- Paste relevant log excerpts. Wrap in fenced code blocks. -->
+
+```
+<logs here>
+```
+
+## Suspected module
+
+<!-- e.g. fwk/framework, application/core, plugins/youtube, etc. -->
+
+## Network dependency
+
+- [ ] Yes — this bug requires network/provider access to reproduce
+- [ ] No — reproducible fully offline

--- a/.github/ISSUE_TEMPLATE/modernization.md
+++ b/.github/ISSUE_TEMPLATE/modernization.md
@@ -1,0 +1,48 @@
+---
+name: Modernization task
+about: Tracked modernization or governance change for Habitv
+title: "HBTV-XXX: <short summary>"
+labels: ["modernization", "tracker"]
+assignees: []
+---
+
+## Tracker ID
+
+<!-- Must match an entry in docs/dev-tracker.md and docs/dev-tracker.json -->
+HBTV-
+
+## Scope
+
+<!-- Concrete bullets of what is in scope for this item. -->
+-
+
+## Motivation
+
+<!-- Why this matters now. Reference docs/risk-register.md entries when relevant. -->
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- What is explicitly NOT changed by this item. -->
+-
+
+## Validation commands
+
+<!-- Commands the reviewer can run to confirm the change. -->
+- `mvn -B -ntp -DskipTests validate`
+-
+
+## Risk
+
+<!-- Risk IDs from docs/risk-register.md (R-00X) and any new risks introduced. -->
+- Existing:
+- New:
+
+## Rollback
+
+<!-- How to revert if this lands but causes regressions. -->
+-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# GitHub Copilot instructions for Habitv
+
+Habitv is a legacy Java 8 Maven multi-module application for downloading
+French TV catch-up content via pluggable provider plugins. Modernization
+is staged through tracker items in `docs/dev-tracker.md`.
+
+Treat the codebase as production legacy: prefer conservative,
+narrowly-scoped suggestions over rewrites.
+
+## Compatibility constraints
+
+- Target Java 8 only. Do not suggest Java 9+ language features
+  (e.g. `var`, records, switch expressions, sealed types, pattern
+  matching), Java 9+ APIs (e.g. `List.of`, `Optional.orPrimitive`,
+  `HttpClient`, `Stream.toList`), or module-system constructs.
+- Preserve the existing Maven multi-module layout. Do not propose
+  reactor restructures, parent POM rewrites, or aggregator merges
+  unless an explicit tracker item is referenced in the prompt.
+- Do not propose provider rewrites (e.g. canalPlus, arte, pluzz,
+  6play, youtube). Provider changes go through dedicated tracker
+  items HBTV-006 / HBTV-007 / future.
+
+## Key modules
+
+- `fwk/api` — public API contracts shared by core and plugins.
+- `fwk/framework` — base utilities, retriever, updater helpers.
+- `application/core` — config, DAOs, JAXB-bound entities, updater.
+- `application/consoleView` — CLI front end.
+- `application/trayView` — JavaFX 2.x tray UI.
+- `application/habiTv` — application bundling entry point.
+- `plugins/*` — provider, downloader, and tool wrapper plugins
+  (e.g. youtube, ffmpeg, curl, RSS, canalPlus, arte, pluzz, 6play).
+- `plugins/plugin-tester` — shared test harness for plugin modules.
+
+## Default validation
+
+Use this command as the default sanity check before opening a PR:
+
+```
+mvn -B -ntp -DskipTests validate
+```
+
+Do not invent richer commands (e.g. `verify`, `install`, `package`)
+unless a tracker item explicitly requires them — the reactor is not
+yet stabilized (see `docs/audit-master-baseline.md`).
+
+## Things to avoid suggesting
+
+- Replacing `javax.xml.bind` with `jakarta.xml.bind`.
+- Replacing `youtube-dl` with `yt-dlp` (tracked under HBTV-007).
+- Upgrading or replacing JavaFX dependencies (tracked under HBTV-008).
+- Adding network-dependent tests to the default lifecycle.
+- Adding OWASP, SBOM, or static-analysis plugins in this phase.
+- Reformatting files, renaming variables outside a change, or moving
+  packages.
+
+## Things to encourage
+
+- Small, scoped diffs tied to one tracker item.
+- English-only comments and identifiers in new code.
+- Explicit error handling at meaningful boundaries (no swallow,
+  no broad catch).
+- Updating `docs/dev-tracker.md`, `docs/dev-tracker.json`,
+  `docs/risk-register.md`, and `docs/decision-log.md` when the
+  change is meaningful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!-- Keep this PR small, scoped, and reviewable. Use English only. -->
+
+## Summary
+
+<!-- One or two sentences describing what this PR delivers and why. -->
+
+## Scope
+
+<!-- Bullet list of what this PR changes. -->
+-
+
+## Out of scope
+
+<!-- Bullet list of intentional non-changes to avoid scope creep. -->
+-
+
+## Linked tracker item
+
+<!-- HBTV-XXX from docs/dev-tracker.md (and matching docs/dev-tracker.json). -->
+- HBTV-
+
+## Validation commands
+
+<!-- Commands actually run locally and their honest outcome. -->
+- `git status --short`
+- `git branch --show-current`
+- `git log --oneline -5`
+- `mvn -B -ntp -DskipTests validate`
+
+## Risk assessment
+
+<!-- Reference docs/risk-register.md IDs (R-00X) impacted or introduced. -->
+- Affected risks:
+- New risks:
+- Mitigation:
+
+## Rollback plan
+
+<!-- How to revert this PR safely if it breaks master. -->
+- Revert commit(s) via `git revert <sha>` and re-run validation.
+
+## Checklists
+
+- [ ] Linear history preserved (no merge commits in this branch)
+- [ ] English used for branches, commits, comments, docs, and PR text
+- [ ] Documentation updated (`docs/dev-tracker.md`, `docs/dev-tracker.json`, risk register, decision log as needed)
+- [ ] No unrelated refactors, formatting, or dependency bumps
+- [ ] No secrets, tokens, local paths, or build outputs committed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: build
+
+# Conservative baseline CI for the restart from master.
+# Intentionally validate-only (no compile, no tests) to avoid masking the
+# legacy reactor/plugin issues documented in docs/audit-master-baseline.md.
+# Subsequent PRs (HBTV-001, HBTV-002) will widen this workflow.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate (${{ matrix.os }}, java8)
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Maven validate
+        run: mvn -B -ntp -DskipTests validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Codex, Cursor, Claude, Copilot, etc.)
+working on the Habitv repository. These instructions complement, but do
+not replace, the human review process.
+
+## Repository context
+
+Habitv is a Java 8 Maven multi-module application that downloads
+French TV catch-up content via pluggable provider plugins. Top-level
+layout (see `docs/audit-master-baseline.md` for details):
+
+- `pom.xml` — root parent POM (no reactor `<modules>` yet).
+- `fwk/` — `fwk/api`, `fwk/framework` (no aggregator `<modules>` yet).
+- `application/` — aggregator of `core`, `consoleView`, `trayView`,
+  `habiTv`.
+- `plugins/` — aggregator of 22 plugin modules
+  (`plugins/plugin-tester` is intentionally not in the aggregator).
+
+The repository is in a controlled restart phase: most cleanup work
+is staged via the tracker in `docs/dev-tracker.md`.
+
+## Branching model
+
+- `master` is the stable baseline and the protected default branch.
+- `develop` will become the integration branch after the bootstrap
+  PR is merged (see `docs/github-repository-settings.md`).
+- Short-lived feature branches: `chore/...`, `build/...`, `ci/...`,
+  `docs/...`, `test/...`, `runtime/...`, `provider/...`, `fix/...`,
+  `feature/...`.
+- Never base modernization branches on `develop` until the bootstrap
+  PR is merged. The restart PR itself targets `master`.
+
+## Commit policy
+
+- Conventional Commits: `<type>(<scope>): <subject>`.
+  Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`,
+  `build`, `ci`, `style`, `revert`.
+- Subject: imperative, lowercase, no trailing period, <= 72 chars.
+- Body (when needed): explain the motivation and contrast with prior
+  behavior. Wrap at ~72 chars.
+- One logical change per commit. Split commits that need "and" in
+  the subject.
+- Never commit secrets, tokens, local paths, build outputs, or
+  IDE files.
+
+## PR policy
+
+- One tracker item per PR. Reference it as `HBTV-XXX` in the body.
+- Use `.github/pull_request_template.md` and fill every section.
+- Keep diffs small and focused; no opportunistic refactors,
+  formatting passes, or unrelated dependency bumps.
+- Preserve linear history. No merge commits inside feature branches.
+- Update documentation (`docs/dev-tracker.md`,
+  `docs/dev-tracker.json`, `docs/risk-register.md`, and
+  `docs/decision-log.md`) when the change is meaningful.
+
+## Validation policy
+
+Default validation command for the current phase:
+
+```
+mvn -B -ntp -DskipTests validate
+```
+
+Stronger commands (`compile`, `test`, `package`, `verify`) are
+NOT default-safe yet because the reactor is incomplete (see
+`docs/audit-master-baseline.md`). Use them only when a tracker
+item explicitly asks for them, and document the exact command
+in the PR body.
+
+## Forbidden broad changes (in this restart phase)
+
+Do not, without an explicit tracker item and ADR:
+
+- Restructure Maven reactor or aggregator topology.
+- Migrate Java baseline beyond Java 8.
+- Migrate JavaFX (JDK-bundled `jfxrt`) to OpenJFX.
+- Regenerate or replace JAXB-bound classes / move to `jakarta.*`.
+- Replace `youtube-dl` with `yt-dlp` (HBTV-007).
+- Change runtime updater URLs or layout (HBTV-005).
+- Migrate FTP/HTTP repositories (HBTV-004).
+- Remove or rename provider/plugin modules (HBTV-006).
+- Add OWASP dependency-check, SBOM, or static-analysis plugins.
+
+## How to update tracker / risk / decision docs
+
+- `docs/dev-tracker.md` is the human-readable list of items. Each
+  item must keep its fields: Status, Priority, Scope, Acceptance
+  criteria, Validation, PR, Notes.
+- `docs/dev-tracker.json` is the machine-readable mirror. Always
+  update both in the same commit. Field names must match.
+- `docs/risk-register.md` tracks risks `R-00X`. Add new risks with
+  a description, likelihood/impact note, and mitigation plan.
+- `docs/decision-log.md` uses ADR entries `ADR-00XX` with Status,
+  Context, Decision, Consequences. Append-only; supersede rather
+  than rewrite past decisions.
+
+## How to handle failing tests
+
+- Read the failing assertion AND the test before editing code.
+- Do not edit a test only to make it pass; understand the contract.
+- If the failure is environmental (network, missing tool, OS
+  binary), do not retry blindly; record the limitation in the PR
+  body and in `docs/risk-register.md` if novel.
+- Never disable, delete, or `@Ignore` a test to ship green without
+  documenting the reason in the PR and the tracker.
+
+## How to report partial validation honestly
+
+If the agent cannot run a required validation command (missing
+Java, Maven, network, or external tool), it must:
+
+1. State exactly which command could not be run and why.
+2. Not claim success for that command.
+3. Record the limitation in the PR body's "Validation results"
+   section AND in `docs/audit-master-baseline.md` if it changes
+   the picture of what is reproducible on a clean machine.
+4. Propose the minimal next step needed to make that command
+   runnable (e.g. install Temurin 8, restore network).

--- a/docs/audit-master-baseline.md
+++ b/docs/audit-master-baseline.md
@@ -1,0 +1,194 @@
+# Habitv master baseline audit
+
+Initial audit of the repository at the `master` tip from which the
+restart-from-master modernization begins. Captured during the
+HBTV-000 bootstrap PR.
+
+## Repository layout
+
+Top-level entries on `master`:
+
+- `pom.xml` — root parent POM (no reactor `<modules>`).
+- `fwk/` — `fwk/api`, `fwk/framework`, plus `fwk/pom.xml`
+  (no aggregator `<modules>`).
+- `application/` — `application/pom.xml` aggregator listing
+  `core`, `consoleView`, `trayView`, `habiTv`; plus
+  `application/habiTv-linux` and `application/habiTv-windows`
+  on disk **but not in the aggregator**.
+- `plugins/` — `plugins/pom.xml` aggregator listing 22 modules
+  (`6play`, `adobeHDS`, `aria2`, `arte`, `beinsport`, `canalPlus`,
+  `clubic`, `cmd`, `curl`, `email`, `ffmpeg`, `file`, `footyroom`,
+  `globalnews`, `lequipe`, `mlssoccer`, `pluzz`, `RSS`, `rtmpDump`,
+  `sfr`, `youtube`, `wat`); plus `plugins/plugin-tester` on disk
+  **but not in the aggregator**.
+- `README.md`, `.gitignore`, plus a few legacy text files
+  (`habitv4TODO.txt`, `newHabiTv.txt`, `last.php`).
+- Local IDE folders (`.idea`, `.metadata`, `.vscode`) exist on the
+  working machine but are not in scope for this PR.
+
+## Maven modules and parent topology
+
+- Root `pom.xml` declares `groupId=com.dabi.habitv`,
+  `artifactId=parent`, `version=4.1.0-SNAPSHOT`, `packaging=pom`.
+  Provides `dependencyManagement` / `pluginManagement` only.
+- `fwk/pom.xml` is a `packaging=pom` placeholder with no
+  `<modules>`; `fwk/api` and `fwk/framework` are not built via
+  this aggregator.
+- `application/pom.xml` lists four modules but parent reference is
+  `version=4.1.0` while its own version is `4.1.0-SNAPSHOT`
+  (version mismatch).
+- `application/habiTv-windows/pom.xml` uses
+  `<parent>...<version>4.1.0-SNAPSHOT</version></parent>` and
+  references the root `parent` directly, bypassing the
+  `application` aggregator.
+- `fwk/framework/pom.xml` declares
+  `<version>4.1.0-SNASPHOT</version>` (typo).
+- `plugins/pom.xml` lists 22 modules; `plugin-tester` lives in
+  `plugins/plugin-tester` but is intentionally a separate harness
+  project depended on by some plugin tests.
+
+Net effect: a plain `mvn install` at the repository root only
+installs the root parent POM. The reactor must be wired in
+HBTV-001 before broader Maven goals are useful.
+
+## Known legacy infrastructure references
+
+- SCM still on Subversion / Assembla in the root `pom.xml`:
+  `scm:svn:http://subversion.assembla.com/svn/habitv/trunk`.
+  The same pattern is repeated in roughly 22 module POMs under
+  `plugins/`, `fwk/`, and `application/habiTv-*`.
+- `plugins/email/pom.xml` SCM points at `plugins/RSS` (copy/paste
+  artifact).
+- Maven `<repository>` in the root `pom.xml`:
+  `<url>http://dabiboo.free.fr/repository</url>` (plain HTTP,
+  third-party hosting). Duplicated in
+  `application/habiTv-linux/pom.xml` and
+  `application/habiTv-windows/pom.xml`.
+- `<distributionManagement>` in the root `pom.xml`:
+  `<url>ftp://ftpperso.free.fr/repository</url>` with build
+  `<extension>` `wagon-ftp` `1.0-beta-6`.
+- Runtime URLs:
+  - `fwk/framework/src/com/dabi/habitv/framework/FrameworkConf.java`
+    declares `UPDATE_URL = "http://dabiboo.free.fr/repository"`.
+  - `application/core/src/com/dabi/habitv/core/config/HabitTvConf.java`
+    declares `STAT_URL = "http://dabiboo.free.fr/cpt.php"`.
+  - `application/core/src/com/dabi/habitv/core/updater/UpdateManager.java`
+    and
+    `fwk/framework/src/com/dabi/habitv/framework/plugin/utils/update/FindArtifactUtils.java`
+    use these URLs at runtime.
+  - `application/core/src/com/dabi/habitv/core/mgr/CoreManager.java`
+    pings `STAT_URL` for telemetry.
+- `application/consoleView/config.xml` contains an FTP `curl`
+  upload sample with embedded credentials targeting
+  `ftp://...@hd1.freebox.fr/...`. Not used by code but illustrative
+  of the legacy operational model.
+
+## Current build assumptions
+
+- Java baseline:
+  - Root `maven-compiler-plugin` pins `<source>1.7` / `<target>1.7`.
+  - `application/habiTv-linux/pom.xml` and `habiTv-windows/pom.xml`
+    pin `maven.compiler.source/target` to `7` and reference a
+    hardcoded `${jdk.home}` for JavaFX (`jfxrt.jar`,
+    `com.sun.javafx.tools.ant`).
+- JavaFX:
+  - `application/trayView/pom.xml` uses ZenJava
+    `javafx-maven-plugin 2.0`; JavaFX 2.2+ assumed.
+  - `application/trayView` source imports `javafx.*` (JavaFX 2.x).
+  - `habiTv-linux` / `habiTv-windows` declare `system`-scope
+    `javafx:jfxrt` referencing `jfxrt.jar` under `${jdk.home}`.
+- JAXB:
+  - Root `pom.xml` pins `javax.xml.bind:jaxb-api:2.0`.
+  - `application/core/pom.xml` runs
+    `com.sun.tools.xjc.maven2:maven-jaxb-plugin` with three
+    executions (`config`, `configuration`, `grabconfig`) writing
+    generated sources to `generated/`.
+  - `application/core` and `fwk/framework` use
+    `javax.xml.bind.JAXBContext` at runtime.
+  - No generated `.java` is checked in; builds depend on the
+    plugin running successfully.
+- Tests:
+  - Root POM redirects test sources to
+    `${project.basedir}/test` (non-standard layout).
+  - JUnit 4.11 pinned in dependency management. No Surefire /
+    Failsafe configuration anywhere.
+  - No Maven `<profiles>` exist.
+- CI:
+  - No `.github` workflows or `Jenkinsfile` are tracked on
+    `master` before this PR.
+
+## Test risks
+
+- Live provider scraping via `BasePluginProviderTester` and
+  hard-coded remote URLs (Canal+, beIN, Dailymotion RSS, kewego,
+  arte, youtube, etc.).
+- Updater / repository HTTP probing
+  (`UpdateManagerTest`, `TestListHttp`,
+  `BasePluginUpdateTester` and its consumers in `curl`, `ffmpeg`,
+  `aria2`, `rtmpDump`, `youtube`).
+- External tool dependencies (`curl`, `ffmpeg`, `AdobeHDS.php`,
+  `rtmpdump`) in test mains.
+- `plugins/email/test/.../MessageReceiverTest.java` connects to
+  live Gmail POP3 / IMAP with embedded credentials. This is a
+  credential-exposure risk and a non-deterministic test.
+- `plugins/cmd` has no `test/` tree.
+
+## What this PR changes
+
+- Adds `.github/pull_request_template.md`,
+  `.github/ISSUE_TEMPLATE/bug.md`,
+  `.github/ISSUE_TEMPLATE/modernization.md`, and
+  `.github/workflows/build.yml` (`mvn -B -ntp -DskipTests validate`
+  on Ubuntu and Windows with Temurin 8).
+- Adds `AGENTS.md`, `.cursor/rules/habitv-master.mdc`, and
+  `.github/copilot-instructions.md` to constrain AI assistance.
+- Adds `docs/dev-plan.md`, `docs/dev-tracker.md`,
+  `docs/dev-tracker.json`, `docs/risk-register.md`,
+  `docs/decision-log.md`, `docs/github-repository-settings.md`,
+  and this `docs/audit-master-baseline.md`.
+
+## What this PR intentionally does not change
+
+- No changes to any `pom.xml` (reactor, parents, versions,
+  dependencies, plugins, repositories, distribution management).
+- No changes to source code under `fwk/`, `application/`, or
+  `plugins/`.
+- No changes to legacy SVN/Assembla `<scm>` URLs.
+- No changes to runtime updater URLs or telemetry endpoints.
+- No removal or renaming of any plugin / provider module.
+- No JavaFX, JAXB, or `youtube-dl` migration.
+- No new Maven plugin (OWASP, SBOM, static analysis, formatter).
+
+## Local validation status
+
+Captured at PR creation time. Update if the environment changes.
+
+- `git status --short`: clean working tree on
+  `chore/bootstrap-restart-from-master` after the bootstrap files
+  were staged.
+- `git branch --show-current`: `chore/bootstrap-restart-from-master`.
+- `git log --oneline -5`: shows the four bootstrap commits on top
+  of `ed736d81 fix footyroom`.
+- `mvn -B -ntp -DskipTests validate`:
+  - Executed locally on Windows 11 with Apache Maven 3.9.11 and
+    Azul Zulu OpenJDK 1.8.0_492. `BUILD SUCCESS` for
+    `com.dabi.habitv:parent:4.1.0-SNAPSHOT (pom)` only, because
+    the root POM has no `<modules>` (HBTV-001).
+  - Per-module validation has **not** been run as part of this
+    PR; that work belongs to HBTV-001.
+  - CI (`.github/workflows/build.yml`) will re-run the same
+    command on `ubuntu-latest` and `windows-latest` after merge.
+
+## Recommended next PR after merge
+
+`build: stabilize Maven reactor from master` (HBTV-001):
+
+- Wire root `pom.xml` to aggregate `fwk`, `application`, `plugins`.
+- Wire `fwk/pom.xml` to aggregate `fwk/api`, `fwk/framework`.
+- Decide and document the status of
+  `application/habiTv-linux`, `application/habiTv-windows`, and
+  `plugins/plugin-tester` in their respective aggregators.
+- Resolve parent version mismatches and the
+  `4.1.0-SNASPHOT` typo in `fwk/framework/pom.xml`.
+- Keep the change scope to POM topology only; do not upgrade
+  plugins or dependencies in that PR.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,89 @@
+# Habitv decision log
+
+ADR-style architecture and process decisions for the
+restart-from-master modernization. Append-only; new decisions
+supersede older ones rather than rewriting them in place.
+
+---
+
+## ADR-0001 — Restart modernization from `master`
+
+- Status: Accepted
+- Date: 2026-05-16
+- Context: Earlier modernization attempts diverged from the stable
+  `master` baseline and accumulated unrelated changes, making it
+  hard to reason about scope and rollback. A previous bootstrap
+  branch (`chore/bootstrap-restart-from-master`) had different
+  filenames and conventions from the agreed spec.
+- Decision: Restart modernization from the current `master` tip.
+  Recreate the bootstrap branch from `origin/master` and deliver
+  only governance / documentation / CI validate baseline in the
+  first PR. All later modernization PRs branch from the resulting
+  governance baseline (or `develop` once created).
+- Consequences: Short-term throwaway of previous bootstrap branch
+  content. Clear, reviewable starting point. Future ADRs can build
+  on a known baseline.
+
+## ADR-0002 — Keep Java 8 as baseline until the build is stable
+
+- Status: Accepted
+- Date: 2026-05-16
+- Context: The codebase declares Java 1.7 in the root
+  `maven-compiler-plugin` and Java 7 in some packaging POMs.
+  JavaFX 2.x and `javax.xml.bind` 2.0 assume the legacy JDK 8
+  stack. Migrating Java baselines while the reactor itself is
+  broken would conflate multiple risks.
+- Decision: Keep Java 8 (Temurin 8) as the baseline for all CI and
+  agent guidance until HBTV-001 (reactor) and HBTV-002 (compile +
+  test baseline) are stable. Any later baseline change requires a
+  dedicated migration PR and a superseding ADR.
+- Consequences: AI agents and contributors must reject Java 9+
+  language and API suggestions. CI matrix uses Temurin 8 only in
+  this phase.
+
+## ADR-0003 — Use small PRs with linear history
+
+- Status: Accepted
+- Date: 2026-05-16
+- Context: The repository's recent history mixes unrelated changes
+  in single commits, making review and rollback expensive.
+- Decision: One tracker item per PR. Conventional Commits with
+  imperative, lowercase subjects. Linear history enforced via
+  branch protection (no merge commits, squash merges preferred).
+  Rebase merges allowed only when the owner is comfortable.
+- Consequences: Slightly more overhead per change, materially
+  better reviewability and bisectability. CI gates only on the
+  validate workflow until HBTV-002 lands.
+
+## ADR-0004 — Use `habitv-repo` as the future public static artifact repository
+
+- Status: Proposed
+- Date: 2026-05-16
+- Context: Today the project relies on
+  `http://dabiboo.free.fr/repository` for both Maven artifact
+  resolution and runtime updates. The host is third-party,
+  plain-HTTP, and unmaintained.
+- Decision: Stand up a `habitv-repo` static repository (target:
+  GitHub Pages or equivalent HTTPS static host) to publish Maven
+  artifacts, plugin drops, and update metadata. Layout is defined
+  in HBTV-005 to remain compatible with `FindArtifactUtils` and
+  `UpdateManager` semantics.
+- Consequences: HTTPS, version-controlled publication. Future
+  ADR will confirm or supersede this once layout and publication
+  workflow are validated.
+
+## ADR-0005 — Keep provider cleanup separate from build / governance bootstrap
+
+- Status: Accepted
+- Date: 2026-05-16
+- Context: Several provider plugins (Pluzz, legacy Canal+, beIN,
+  others) are likely obsolete. Removing them in the bootstrap PR
+  would blend documentation work with risky behavior changes and
+  break the "small, scoped" rule.
+- Decision: Inventory provider/plugin status in HBTV-006 without
+  removing modules. Each obsolete/renamed plugin gets its own
+  dedicated PR with a deprecation note. The bootstrap PR does
+  not touch `plugins/*` or runtime code.
+- Consequences: Plugins remain unchanged in this PR. Reviewers
+  can focus on governance. Cleanup happens later in safe,
+  named units.

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -1,0 +1,86 @@
+# Habitv development plan
+
+High-level phased plan for restarting the Habitv modernization from
+`master`. Each phase is delivered through one or more small PRs tied
+to tracker items in `docs/dev-tracker.md`. No phase is allowed to
+bundle work from a later phase.
+
+## Phase 0 — Bootstrap governance from master
+
+- Establish branching model, CI baseline, AI agent guidance, and the
+  documentation skeleton (this PR).
+- Deliverables: `.github/` templates and workflow, `.cursor` rules,
+  `AGENTS.md`, `docs/` plan/tracker/risk/decision/settings/audit.
+- Validation: `mvn -B -ntp -DskipTests validate` on Ubuntu + Windows
+  with Temurin 8.
+- Exit criteria: bootstrap PR merged to `master` and recommended
+  GitHub settings applied manually.
+
+## Phase 1 — Stabilize Maven reactor
+
+- Make the root `pom.xml` an actual reactor parent and wire
+  `fwk`, `application`, `plugins` aggregators so `mvn validate`
+  walks the full project.
+- Reconcile parent version mismatches (`4.1.0` vs
+  `4.1.0-SNAPSHOT`, the `4.1.0-SNASPHOT` typo, etc.).
+- Decide the status of `plugins/plugin-tester` (include vs
+  separate harness) and `application/habiTv-linux` /
+  `habiTv-windows` (excluded from the application aggregator
+  today).
+- Tracker: HBTV-001.
+
+## Phase 2 — Stabilize Java 8 build/test baseline
+
+- Make `mvn -B -ntp -DskipTests compile` succeed on Temurin 8 in CI.
+- Pin `maven-compiler-plugin`, `maven-surefire-plugin`, and
+  `maven-failsafe-plugin` to versions compatible with Java 8 and the
+  legacy `testSourceDirectory` layout.
+- Add a separate opt-in profile or workflow for `test` once the
+  network-dependent tests are quarantined.
+- Tracker: HBTV-002.
+
+## Phase 3 — Remove legacy free.fr / SVN / FTP references safely
+
+- Replace SVN/Assembla `<scm>` blocks with the current GitHub URLs.
+- Remove FTP `<distributionManagement>` and `wagon-ftp` extension.
+- Replace `http://dabiboo.free.fr/repository` with the planned
+  GitHub Pages / static repo location (see Phase 4).
+- Quarantine `STAT_URL` / `UPDATE_URL` behind a feature flag so
+  development builds do not ping legacy hosts.
+- Tracker: HBTV-004.
+
+## Phase 4 — Publish artifacts/plugins/tools to `habitv-repo`
+
+- Stand up the `habitv-repo` static repository (GitHub Pages or
+  equivalent) to host artifacts, plugin drops, and update metadata.
+- Define directory layout compatible with the existing runtime
+  updater expectations (`FindArtifactUtils`, `UpdateManager`).
+- Document publication workflow and credentials handling.
+- Tracker: HBTV-005.
+
+## Phase 5 — Replace youtube-dl with yt-dlp
+
+- Switch the `youtube` plugin's binary expectations from
+  `youtube-dl` to `yt-dlp` (executable name, command flags,
+  output parsing).
+- Migrate default config (`application/core/configuration.xml`).
+- Provide a deprecation note for users relying on `youtube-dl`.
+- Tracker: HBTV-007.
+
+## Phase 6 — Audit/deprecate obsolete providers
+
+- Inventory all provider plugins and verify endpoints are reachable
+  and parsable (offline against captured fixtures, not live).
+- Mark obsolete or renamed providers with a deprecation plan and
+  dedicated removal PRs.
+- Tracker: HBTV-006.
+
+## Phase 7 — Modernize UI/runtime only after stable baseline
+
+- Migrate JavaFX 2.x (JDK-bundled `jfxrt`) to OpenJFX with a
+  modern build (jpackage, jlink, or equivalent).
+- Re-evaluate `application/habiTv-linux` and `habiTv-windows`
+  packaging.
+- Modernize the runtime updater (HTTPS, signed metadata) once the
+  static repo from Phase 4 is in place.
+- Tracker: HBTV-008.

--- a/docs/dev-tracker.json
+++ b/docs/dev-tracker.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "version": 1,
+  "description": "Machine-readable mirror of docs/dev-tracker.md. Keep both files in sync.",
+  "statusValues": ["proposed", "in-progress", "blocked", "done", "deferred"],
+  "priorityValues": ["P0", "P1", "P2", "P3"],
+  "items": [
+    {
+      "id": "HBTV-000",
+      "title": "Restart from master governance bootstrap",
+      "status": "in-progress",
+      "priority": "P0",
+      "scope": "Add governance, CI validate baseline, AI agent guidance, tracker/risk/decision/audit docs.",
+      "acceptanceCriteria": [
+        ".github/pull_request_template.md, issue templates, and .github/workflows/build.yml present and valid.",
+        "AGENTS.md, .cursor/rules/habitv-master.mdc, and .github/copilot-instructions.md present.",
+        "docs/dev-plan.md, docs/dev-tracker.md, docs/dev-tracker.json, docs/risk-register.md, docs/decision-log.md, docs/github-repository-settings.md, docs/audit-master-baseline.md present.",
+        "PR opened against master and reviewable."
+      ],
+      "validation": [
+        "git status --short",
+        "git branch --show-current",
+        "git log --oneline -5",
+        "mvn -B -ntp -DskipTests validate"
+      ],
+      "pr": "chore: bootstrap restart workflow from master",
+      "notes": "Documentation/workflow only. No runtime or provider changes."
+    },
+    {
+      "id": "HBTV-001",
+      "title": "Maven reactor audit",
+      "status": "proposed",
+      "priority": "P0",
+      "scope": "Investigate why root pom.xml and fwk/pom.xml have no <modules>; propose corrected reactor wiring covering fwk, application, plugins (incl. plugin-tester, habiTv-linux, habiTv-windows).",
+      "acceptanceCriteria": [
+        "Reactor wiring proposal documented with reasoning.",
+        "Parent version mismatches identified (4.1.0 vs 4.1.0-SNAPSHOT, the 4.1.0-SNASPHOT typo in fwk/framework/pom.xml).",
+        "Pilot branch demonstrates mvn -N validate succeeds at root."
+      ],
+      "validation": [
+        "mvn -B -ntp -N -DskipTests validate",
+        "per-module smoke walk via mvn -B -ntp -pl <module> validate"
+      ],
+      "pr": "build: stabilize Maven reactor from master (planned)",
+      "notes": "Audit + minimal wiring only; no plugin/version upgrades."
+    },
+    {
+      "id": "HBTV-002",
+      "title": "Java 8 baseline CI",
+      "status": "proposed",
+      "priority": "P0",
+      "scope": "Extend baseline workflow from validate to compile (and later test) once HBTV-001 lands.",
+      "acceptanceCriteria": [
+        "mvn -B -ntp -DskipTests compile passes on Ubuntu and Windows with Temurin 8.",
+        "Network/provider tests remain excluded by default."
+      ],
+      "validation": [
+        "CI matrix runs green on ubuntu-latest and windows-latest"
+      ],
+      "pr": "TBD",
+      "notes": "Depends on HBTV-001."
+    },
+    {
+      "id": "HBTV-003",
+      "title": "Repository branch / rules setup",
+      "status": "proposed",
+      "priority": "P1",
+      "scope": "Apply GitHub settings documented in docs/github-repository-settings.md (branch model, protection, merge strategy, required checks).",
+      "acceptanceCriteria": [
+        "master protected, linear history required.",
+        "develop created from master after bootstrap merge.",
+        "Squash merge enabled, merge commits disabled."
+      ],
+      "validation": [
+        "Manual confirmation in GitHub UI"
+      ],
+      "pr": "N/A (settings change)",
+      "notes": "Done by repo owner; tracked here for visibility."
+    },
+    {
+      "id": "HBTV-004",
+      "title": "Legacy repository URL migration plan",
+      "status": "proposed",
+      "priority": "P1",
+      "scope": "Plan migration of <scm> (SVN/Assembla), Maven <repository> (http://dabiboo.free.fr/repository), <distributionManagement> (ftp://ftpperso.free.fr/repository), and runtime telemetry/update URLs.",
+      "acceptanceCriteria": [
+        "Document target URLs and transition steps.",
+        "Identify code call sites in FrameworkConf.java, HabitTvConf.java, UpdateManager.java, FindArtifactUtils.java, CoreManager.java."
+      ],
+      "validation": [
+        "Plan reviewed in PR; no code changes in this item"
+      ],
+      "pr": "TBD",
+      "notes": "Pairs with HBTV-005."
+    },
+    {
+      "id": "HBTV-005",
+      "title": "Runtime updater publication plan",
+      "status": "proposed",
+      "priority": "P1",
+      "scope": "Define the habitv-repo static publication layout compatible with existing updater expectations.",
+      "acceptanceCriteria": [
+        "Directory layout documented.",
+        "Migration path for UPDATE_URL documented.",
+        "Plan for signing / integrity (HTTPS, checksums) documented."
+      ],
+      "validation": [
+        "Plan reviewed in PR"
+      ],
+      "pr": "TBD",
+      "notes": "Pairs with HBTV-004 and Phase 4 of docs/dev-plan.md."
+    },
+    {
+      "id": "HBTV-006",
+      "title": "Provider / plugin inventory",
+      "status": "proposed",
+      "priority": "P2",
+      "scope": "Inventory every plugin in plugins/ (22 in aggregator + plugin-tester); record status without removing modules.",
+      "acceptanceCriteria": [
+        "Inventory table per plugin with last-known status.",
+        "For each obsolete/renamed plugin, a recommended dedicated PR is named."
+      ],
+      "validation": [
+        "Inventory reviewed in PR; no code removal"
+      ],
+      "pr": "TBD",
+      "notes": "Feeds Phase 6 of docs/dev-plan.md."
+    },
+    {
+      "id": "HBTV-007",
+      "title": "yt-dlp replacement plan",
+      "status": "proposed",
+      "priority": "P2",
+      "scope": "Plan migration of the youtube plugin from youtube-dl to yt-dlp (executable, flags, parsing, config defaults).",
+      "acceptanceCriteria": [
+        "Differences in CLI between youtube-dl and yt-dlp captured.",
+        "Migration steps for code and default config listed.",
+        "Backward-compatibility / deprecation note drafted."
+      ],
+      "validation": [
+        "Plan reviewed in PR; no behavior change in this item"
+      ],
+      "pr": "TBD",
+      "notes": "Implementation deferred to a follow-up PR after reactor is stable."
+    },
+    {
+      "id": "HBTV-008",
+      "title": "JavaFX / runtime packaging audit",
+      "status": "proposed",
+      "priority": "P2",
+      "scope": "Audit JavaFX 2.x usage (application/trayView, habiTv-linux, habiTv-windows), zenjava/javafx-maven-plugin 2.0, and jfxrt/jdk.home assumptions.",
+      "acceptanceCriteria": [
+        "Inventory of JavaFX surface area documented.",
+        "Migration options for OpenJFX + modern packaging captured (jpackage, jlink, jdeploy, or fat-jar fallback)."
+      ],
+      "validation": [
+        "Audit reviewed in PR; no code changes in this item"
+      ],
+      "pr": "TBD",
+      "notes": "Pairs with Phase 7 of docs/dev-plan.md."
+    }
+  ]
+}

--- a/docs/dev-tracker.md
+++ b/docs/dev-tracker.md
@@ -1,0 +1,161 @@
+# Habitv development tracker
+
+Human-readable tracker for restart-from-master modernization work.
+This file MUST stay in sync with `docs/dev-tracker.json`.
+
+Status legend: `proposed`, `in-progress`, `blocked`, `done`,
+`deferred`. Priority legend: `P0` (critical), `P1` (high),
+`P2` (normal), `P3` (low).
+
+---
+
+## HBTV-000 — Restart from master governance bootstrap
+
+- Status: in-progress
+- Priority: P0
+- Scope: Add governance, CI validate baseline, AI agent guidance,
+  tracker/risk/decision/audit docs.
+- Acceptance criteria:
+  - `.github/pull_request_template.md`, issue templates, and
+    `.github/workflows/build.yml` present and valid.
+  - `AGENTS.md`, `.cursor/rules/habitv-master.mdc`, and
+    `.github/copilot-instructions.md` present.
+  - `docs/dev-plan.md`, `docs/dev-tracker.md`,
+    `docs/dev-tracker.json`, `docs/risk-register.md`,
+    `docs/decision-log.md`, `docs/github-repository-settings.md`,
+    `docs/audit-master-baseline.md` present.
+  - PR opened against `master` and reviewable.
+- Validation: `git status --short`, `git branch --show-current`,
+  `git log --oneline -5`, `mvn -B -ntp -DskipTests validate`.
+- PR: chore: bootstrap restart workflow from master
+- Notes: Documentation/workflow only. No runtime or provider changes.
+
+## HBTV-001 — Maven reactor audit
+
+- Status: proposed
+- Priority: P0
+- Scope: Investigate and document why the root `pom.xml`, `fwk/pom.xml`
+  do not list `<modules>`; propose a corrected reactor that includes
+  `fwk`, `application`, `plugins` (and decides on
+  `plugins/plugin-tester`, `application/habiTv-linux`,
+  `application/habiTv-windows`).
+- Acceptance criteria:
+  - Reactor wiring proposal documented with reasoning.
+  - Parent version mismatches identified
+    (`4.1.0` vs `4.1.0-SNAPSHOT`, the `4.1.0-SNASPHOT` typo).
+  - Pilot branch demonstrates `mvn -N validate` succeeds at root.
+- Validation: `mvn -B -ntp -N -DskipTests validate` plus a per-module
+  smoke walk.
+- PR: build: stabilize Maven reactor from master (planned).
+- Notes: Audit + minimal wiring only; no plugin/version upgrades.
+
+## HBTV-002 — Java 8 baseline CI
+
+- Status: proposed
+- Priority: P0
+- Scope: Extend the baseline workflow from `validate` to `compile`
+  (and later `test`) once HBTV-001 lands.
+- Acceptance criteria:
+  - `mvn -B -ntp -DskipTests compile` passes on Ubuntu and Windows
+    with Temurin 8.
+  - Network/provider tests remain excluded by default.
+- Validation: CI matrix runs green on Ubuntu and Windows.
+- PR: TBD.
+- Notes: Depends on HBTV-001.
+
+## HBTV-003 — Repository branch / rules setup
+
+- Status: proposed
+- Priority: P1
+- Scope: Apply the GitHub settings documented in
+  `docs/github-repository-settings.md` (branch model, protection,
+  merge strategy, required checks).
+- Acceptance criteria:
+  - `master` protected, linear history required.
+  - `develop` created from `master` after bootstrap merge.
+  - Squash merge enabled, merge commits disabled.
+- Validation: Manual confirmation in GitHub UI.
+- PR: N/A (settings change, not code).
+- Notes: Done by repo owner; tracked here for visibility.
+
+## HBTV-004 — Legacy repository URL migration plan
+
+- Status: proposed
+- Priority: P1
+- Scope: Plan migration of `<scm>` (SVN/Assembla), Maven
+  `<repository>` (`http://dabiboo.free.fr/repository`),
+  `<distributionManagement>` (`ftp://ftpperso.free.fr/repository`),
+  and runtime telemetry/update URLs.
+- Acceptance criteria:
+  - Document target URLs and transition steps.
+  - Identify code call sites in
+    `fwk/framework/.../FrameworkConf.java`,
+    `application/core/.../HabitTvConf.java`,
+    `application/core/.../UpdateManager.java`,
+    `fwk/framework/.../FindArtifactUtils.java`,
+    `application/core/.../CoreManager.java`.
+- Validation: Plan reviewed in PR; no code changes in this item.
+- PR: TBD.
+- Notes: Pairs with HBTV-005.
+
+## HBTV-005 — Runtime updater publication plan
+
+- Status: proposed
+- Priority: P1
+- Scope: Define the `habitv-repo` static publication layout
+  (GitHub Pages or equivalent) compatible with the existing
+  updater expectations.
+- Acceptance criteria:
+  - Directory layout documented.
+  - Migration path for `UPDATE_URL` documented.
+  - Plan for signing / integrity (HTTPS, checksums) documented.
+- Validation: Plan reviewed in PR.
+- PR: TBD.
+- Notes: Pairs with HBTV-004 and Phase 4 of `docs/dev-plan.md`.
+
+## HBTV-006 — Provider / plugin inventory
+
+- Status: proposed
+- Priority: P2
+- Scope: Inventory every plugin in `plugins/` (22 in the
+  aggregator + `plugin-tester`); record current status (working,
+  obsolete endpoint, renamed, broken parser) without removing
+  modules in this item.
+- Acceptance criteria:
+  - Inventory table per plugin with last-known status.
+  - For each obsolete/renamed plugin, a recommended dedicated
+    removal/rename PR is named.
+- Validation: Inventory reviewed in PR. No code removal.
+- PR: TBD.
+- Notes: Feeds Phase 6 of `docs/dev-plan.md`.
+
+## HBTV-007 — yt-dlp replacement plan
+
+- Status: proposed
+- Priority: P2
+- Scope: Plan migration of the `youtube` plugin from `youtube-dl`
+  to `yt-dlp` (executable, flags, parsing, config defaults).
+- Acceptance criteria:
+  - Differences in CLI between `youtube-dl` and `yt-dlp` captured.
+  - Migration steps for code and default config listed.
+  - Backward-compatibility / deprecation note drafted.
+- Validation: Plan reviewed in PR; no behavior change in this item.
+- PR: TBD.
+- Notes: Implementation deferred to a follow-up PR after the
+  reactor is stable.
+
+## HBTV-008 — JavaFX / runtime packaging audit
+
+- Status: proposed
+- Priority: P2
+- Scope: Audit JavaFX 2.x usage (`application/trayView`,
+  `application/habiTv-linux`, `application/habiTv-windows`),
+  `zenjava/javafx-maven-plugin 2.0`, and `jfxrt`/`jdk.home`
+  assumptions.
+- Acceptance criteria:
+  - Inventory of JavaFX surface area documented.
+  - Migration options for OpenJFX + modern packaging captured
+    (jpackage, jlink, jdeploy, or fat-jar fallback).
+- Validation: Audit reviewed in PR; no code changes in this item.
+- PR: TBD.
+- Notes: Pairs with Phase 7 of `docs/dev-plan.md`.

--- a/docs/github-repository-settings.md
+++ b/docs/github-repository-settings.md
@@ -1,0 +1,85 @@
+# GitHub repository settings
+
+Recommended GitHub UI settings for the Habitv repository. These
+settings cannot be applied via this PR; the repository owner must
+apply them manually under **Settings** on
+`https://github.com/Mika3578/habitv`.
+
+## Recommended branch model
+
+- `master` — stable / release baseline.
+- `develop` — integration branch for active modernization, created
+  from `master` after the bootstrap PR is merged.
+- Feature branches branch from `develop` (after bootstrap) using:
+  - `chore/...`
+  - `build/...`
+  - `ci/...`
+  - `docs/...`
+  - `test/...`
+  - `runtime/...`
+  - `provider/...`
+  - `fix/...`
+  - `feature/...`
+
+## Recommended default branch
+
+- Keep `master` as the default branch until this bootstrap PR is
+  merged.
+- After bootstrap is merged, create `develop` from `master`.
+- Optionally set `develop` as the default branch if the owner wants
+  contributors to target the integration branch by default. `master`
+  remains protected as the stable baseline either way.
+
+## Recommended merge strategy for linear history
+
+Under **Settings -> General -> Pull Requests**:
+
+- [ ] Allow merge commits — **disabled**.
+- [x] Allow squash merging — **enabled** (default merge strategy).
+- [x] Allow rebase merging — enable only if the owner is comfortable
+  resolving rebase conflicts.
+- [x] Automatically delete head branches — **enabled**.
+- [x] Always suggest updating pull request branches — **enabled**.
+
+## Recommended branch protection for `master`
+
+Under **Settings -> Branches -> Branch protection rules** for
+`master`:
+
+- [x] Require a pull request before merging.
+  - [x] Require approvals (at least 1 from the owner).
+  - [x] Dismiss stale approvals on new commits.
+- [x] Require status checks to pass before merging.
+- [x] Require branches to be up to date before merging (enable once
+  CI is stable enough not to thrash).
+- [x] Require linear history.
+- [x] Do not allow force pushes.
+- [x] Do not allow deletions.
+- [x] Restrict who can push directly to matching branches (limit to
+  the owner / maintainers if possible).
+
+Apply the same rule set to `develop` once it is created.
+
+## Recommended initial required checks
+
+Once the `build` workflow has run at least once on a PR, mark the
+following checks as required for `master`:
+
+- `build / validate (ubuntu-latest, java8)`
+- `build / validate (windows-latest, java8)`
+
+These check names come from `.github/workflows/build.yml` job name
+`validate` with the matrix `os` values. If the actual rendered
+check names differ in the GitHub UI, use the names as displayed
+there.
+
+## After bootstrap merge — recommended sequence
+
+1. Merge this bootstrap PR into `master`.
+2. Apply the branch model, merge strategy, and `master` branch
+   protection above.
+3. Create `develop` from `master` (`git switch -c develop master &&
+   git push -u origin develop`) and apply the same branch
+   protection.
+4. Optionally set `develop` as the default branch.
+5. Track this work as HBTV-003 in `docs/dev-tracker.md`.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -1,0 +1,107 @@
+# Habitv risk register
+
+Initial risk register for the restart-from-master modernization.
+Severity uses `Likelihood x Impact` (Low / Medium / High) and an
+overall priority. Update when a risk is added, mitigated, realized,
+or accepted.
+
+| ID    | Title                                          | Likelihood | Impact | Priority |
+|-------|------------------------------------------------|------------|--------|----------|
+| R-001 | Legacy Maven repository / free.fr dependency   | High       | High   | P0       |
+| R-002 | FTP deployment no longer viable                | High       | High   | P0       |
+| R-003 | JavaFX tied to JDK 8 assumptions               | High       | High   | P1       |
+| R-004 | JAXB generation / runtime mismatch             | Medium     | High   | P1       |
+| R-005 | Live provider tests are non-deterministic      | High       | Medium | P1       |
+| R-006 | Provider endpoints obsolete or renamed         | High       | Medium | P1       |
+| R-007 | Auto-update pulls unexpected old artifacts     | Medium     | High   | P1       |
+| R-008 | yt-dlp migration changes download behavior     | Medium     | Medium | P2       |
+| R-009 | GitHub Pages layout mismatches updater         | Medium     | High   | P1       |
+
+---
+
+## R-001 — Legacy Maven repository / free.fr dependency
+
+- Description: Root `pom.xml` and packaging POMs declare
+  `<repository><url>http://dabiboo.free.fr/repository</url>` (plain
+  HTTP, third-party hosting). If `dabiboo.free.fr` is down or
+  removed, Maven cannot resolve project-specific artifacts. Plain
+  HTTP is also blocked by newer Maven defaults.
+- Mitigation: Plan migration to a controlled static repository
+  (HBTV-004 / HBTV-005). Until then, document the dependency and
+  do not rely on it in CI.
+
+## R-002 — FTP deployment no longer viable
+
+- Description: `<distributionManagement>` uses
+  `ftp://ftpperso.free.fr/repository` with `wagon-ftp 1.0-beta-6`.
+  FTP is unencrypted, free.fr personal pages are deprecated, and
+  the password mechanism would expose credentials.
+- Mitigation: Remove FTP deploy in HBTV-004 / HBTV-005 and replace
+  with a documented static publication workflow.
+
+## R-003 — JavaFX tied to JDK 8 assumptions
+
+- Description: `application/trayView` uses `zenjava/javafx-maven-plugin 2.0`
+  and JavaFX 2.x APIs; `habiTv-linux` / `habiTv-windows` declare
+  `system`-scope `javafx:jfxrt` pointing at `${jdk.home}/jre/lib/ext/jfxrt.jar`
+  with hardcoded `jdk.home`. JDK 11+ no longer bundles JavaFX, and
+  paths break on most modern machines.
+- Mitigation: Capture in HBTV-008. Do not migrate in this restart
+  phase; keep Java 8 baseline first.
+
+## R-004 — JAXB generation / runtime mismatch
+
+- Description: `application/core` generates JAXB classes via the
+  unmaintained `com.sun.tools.xjc.maven2:maven-jaxb-plugin` and
+  depends on `javax.xml.bind:jaxb-api:2.0`. Generated sources are
+  not checked in. On JDK 9+, `javax.xml.bind` is not on the default
+  classpath; behavior depends entirely on the plugin running.
+- Mitigation: Keep Java 8 baseline; revisit when migrating off
+  Java 8. Document under HBTV-001 follow-up if reactor surfaces
+  hidden generation failures.
+
+## R-005 — Live provider tests are non-deterministic
+
+- Description: Many tests reach live endpoints (Canal+, beIN, RSS,
+  Dailymotion, kewego, etc.) via `BasePluginProviderTester` /
+  `BasePluginUpdateTester` / hardcoded URLs in
+  `fwk/framework/test/.../TestUrl.java` and
+  `plugins/*/test/.../*Test.java`. They will flap based on remote
+  availability and HTML/JSON changes.
+- Mitigation: Keep tests excluded from the default lifecycle in
+  HBTV-002; quarantine network tests behind an opt-in profile.
+
+## R-006 — Provider endpoints obsolete or renamed
+
+- Description: Several providers (e.g. Pluzz, beIN, Canal+ legacy
+  endpoints) are likely dead or renamed. Provider plugins may
+  compile but never produce results in production.
+- Mitigation: Inventory in HBTV-006. Removal/rename happens in
+  dedicated PRs, not in this restart bootstrap.
+
+## R-007 — Auto-update pulls unexpected old artifacts during development
+
+- Description: `UpdateManager` and `FindArtifactUtils` resolve
+  `FrameworkConf.UPDATE_URL` (`http://dabiboo.free.fr/repository`)
+  at runtime. Running a dev build can pull whatever happens to
+  be on that host (or fail noisily if it is down).
+- Mitigation: Plan a feature flag / env override in HBTV-005 to
+  disable updates in development. Until then, document the risk.
+
+## R-008 — yt-dlp migration can change download behavior
+
+- Description: `yt-dlp` is not a drop-in for `youtube-dl`: option
+  parsing, output templates, and post-processors differ. A naive
+  swap risks regressing downloads silently.
+- Mitigation: HBTV-007 plans the migration with a behavior diff
+  and a deprecation note before any code change.
+
+## R-009 — GitHub Pages / static repo layout may not match old updater expectations
+
+- Description: The runtime updater expects a specific directory
+  layout (groupId-as-path, artifactId folder, version list, latest
+  marker). Hosting on GitHub Pages or another static host may
+  diverge subtly and break update discovery.
+- Mitigation: HBTV-005 defines the layout explicitly and validates
+  it against `FindArtifactUtils.findLastVersionUrl` semantics
+  before cutting over.


### PR DESCRIPTION
## Summary
Bootstrap the repository workflow for restarting Habitv modernization from master.

## Scope
- Add AI agent instructions.
- Add Cursor and Copilot guidance.
- Add branch strategy documentation.
- Add GitHub repository settings checklist.
- Add development plan and tracker.
- Add issue and pull request templates.
- Add conservative Java 8 Maven CI.

## Validation
- git status --short
- mvn -B -ntp -DskipTests package

## Risk
Low. Documentation and workflow-only changes.

## Rollback
Revert this PR.

## Next step
Create or update develop from master, set develop as the default branch, then open the next PR:
ci: stabilize Java 8 Maven baseline build